### PR TITLE
Add Dependabot and pin module versions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+Dockerfile
+Containerfile
+*.md
+*.log
+node_modules
+__pycache__

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-releases"
+    directory: "/"
+    allow:
+      - dependency-name: "vozlt/nginx-module-vts"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - name: Get VTS version
+        run: echo "VTS_VERSION=$(grep -oP '^ARG VTS_VERSION=\K.*' Containerfile)" >> $GITHUB_ENV
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Containerfile
+          push: false
+          tags: test:vts-${{ env.VTS_VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * 1'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get VTS version
+        run: echo "VTS_VERSION=$(grep -oP '^ARG VTS_VERSION=\K.*' Containerfile)" >> $GITHUB_ENV
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Containerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ env.VTS_VERSION }}
+          labels: |
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.version=${{ env.VTS_VERSION }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# General
+*.log
+*.tmp
+*.swp
+
+# Editor directories and files
+.*.sw?
+.DS_Store
+
+# Python
+__pycache__/
+*.py[cod]
+
+# Node
+node_modules/
+
+# Build artifacts
+build/
+dist/
+
+# Docker
+*.tar
+
+# Environments
+.env
+
+# GitHub
+/.github/*/node_modules

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+
+ARG NGINX_VERSION=1.26.0
+ARG NGINX_IMAGE=nginx:${NGINX_VERSION}
+ARG VTS_VERSION=v0.2.2
+ARG VTS_REPO=https://github.com/vozlt/nginx-module-vts.git
+
+FROM ${NGINX_IMAGE} AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc make git ca-certificates wget curl jq \
+    libpcre3-dev zlib1g-dev libssl-dev && rm -rf /var/lib/apt/lists/*
+
+# Download Nginx source matching the base image
+RUN curl -fsSL http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz -o nginx.tar.gz && \
+    tar xzf nginx.tar.gz && mv nginx-${NGINX_VERSION} nginx-src
+
+# Build with pinned vts module
+RUN git clone --depth 1 --branch ${VTS_VERSION} ${VTS_REPO} /vts && \
+    cd nginx-src && \
+    ./configure --with-compat --add-dynamic-module=/vts && \
+    make modules
+
+FROM ${NGINX_IMAGE}
+
+# Copy compiled module
+COPY --from=builder /nginx-src/objs/ngx_http_vhost_traffic_status_module.so /usr/lib/nginx/modules/
+
+# Enable module
+RUN mkdir -p /etc/nginx/modules-enabled && \
+    echo "load_module modules/ngx_http_vhost_traffic_status_module.so;" > /etc/nginx/modules-enabled/vts.conf

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # nginx-vts-exporter-container
-Build a nginx image bundled with the nginx-vts-exporter
+
+This repository builds a container image based on the official `nginx` image with the [nginx-module-vts](https://github.com/vozlt/nginx-module-vts) compiled as a dynamic module.
+
+The image is automatically built and published to GitHub Container Registry.
+
+## Usage
+
+```bash
+docker run ghcr.io/<owner>/<repo>:latest
+```
+
+## Development
+
+- `Containerfile` defines the build steps.
+- GitHub Actions build the image on every push and on a weekly schedule.
+- Dependabot monitors updates for the Nginx base image and `nginx-module-vts` releases and will open pull requests when new versions are available.


### PR DESCRIPTION
## Summary
- pin nginx image and vts module versions
- compile module using pinned versions
- remove the update script and workflow
- add Dependabot configuration
- document Dependabot responsibility

## Testing
- `git status --short`